### PR TITLE
[#140488815] Improve forward compatibility

### DIFF
--- a/html/NedapApiWebSocketClient.html
+++ b/html/NedapApiWebSocketClient.html
@@ -41,7 +41,11 @@
         }
 
         function onClose(event, url) {
-            writeToScreen("Disconnected from Renos API WebSocket server " + url);
+            if(event.code) {
+              writeError("Something went wrong. Response code: " + event.code);
+            } else {
+              writeToScreen("Disconnected from Renos API WebSocket server " + url);
+            }
             reconnect();
         }
 

--- a/html/NedapApiWebSocketClient.html
+++ b/html/NedapApiWebSocketClient.html
@@ -42,9 +42,9 @@
 
         function onClose(event, url) {
             if(event.code) {
-              writeError("Something went wrong. Response code: " + event.code);
+                writeError("Something went wrong. Response code: " + event.code);
             } else {
-              writeToScreen("Disconnected from Renos API WebSocket server " + url);
+                writeToScreen("Disconnected from Renos API WebSocket server " + url);
             }
             reconnect();
         }

--- a/java/src/main/java/com/nedap/retail/example/rest/ApiCaller.java
+++ b/java/src/main/java/com/nedap/retail/example/rest/ApiCaller.java
@@ -125,6 +125,8 @@ public class ApiCaller {
             }
         } else if (responseCode == 401) {
             throw new UnauthorizedException("Unauthorized");
+        } else if (responseCode == 404) {
+            throw new NotFoundException("End point not available");
         } else {
             LOG.debug("Message: {}", connection.getResponseMessage());
             return connection.getResponseMessage();

--- a/java/src/main/java/com/nedap/retail/example/rest/ApiCaller.java
+++ b/java/src/main/java/com/nedap/retail/example/rest/ApiCaller.java
@@ -1,15 +1,18 @@
 package com.nedap.retail.example.rest;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Optional;
 
 import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nedap.retail.renos.api.v2.rest.RestMessageParser;
 import com.nedap.retail.renos.api.v2.rest.message.*;
 
@@ -33,44 +36,56 @@ public class ApiCaller {
     public ApiCaller(final String baseUrl) {
         // make sure baseUrl does not end with a slash
         if (baseUrl.endsWith("/")) {
-            this.baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
-        } else {
-            this.baseUrl = baseUrl;
+            throw new IllegalArgumentException("The given URL should not have a trailing \"/\".");
+        }
+
+        this.baseUrl = baseUrl;
+    }
+
+    private <T extends RestObject> T parseAndRethrow(final String json, final Class<T> clazz)
+            throws MessageParsingException {
+        try {
+            return Optional.ofNullable(RestMessageParser.parse(json, clazz))
+                    .orElseThrow(() -> new MessageParsingException(clazz.getSimpleName()));
+        } catch (final IOException e) {
+            throw new MessageParsingException(clazz.getSimpleName());
         }
     }
 
-    public void heartbeat() throws Exception {
+    private <T extends RestObject> String serializeAndRethrow(final T object) {
+        try {
+            return RestMessageParser.toJson(object);
+        } catch (final JsonProcessingException e) {
+            throw new IllegalArgumentException("Serializing to JSON failed.", e);
+        }
+    }
+
+    public void heartbeat() throws HttpRequestException {
         doHttpRequest("/api/v2/heartbeat", GET, null);
     }
 
-    public SystemInfo retrieveSystemInfo() throws Exception {
-        final String info = doHttpRequest("/api/v2/info", GET, null);
-        return RestMessageParser.parse(info, SystemInfo.class);
+    public SystemInfo retrieveSystemInfo() throws HttpRequestException, MessageParsingException {
+        return parseAndRethrow(doHttpRequest("/api/v2/info", GET, null), SystemInfo.class);
     }
 
-    public GroupInfo retrieveGroupInfo() throws Exception {
-        final String info = doHttpRequest("/api/v2/group_info", GET, null);
-        return RestMessageParser.parse(info, GroupInfo.class);
+    public GroupInfo retrieveGroupInfo() throws HttpRequestException, MessageParsingException {
+        return parseAndRethrow(doHttpRequest("/api/v2/group_info", GET, null), GroupInfo.class);
     }
 
-    public SystemStatus retrieveSystemStatus() throws Exception {
-        final String status = doHttpRequest("/api/v2/status", GET, null);
-        return RestMessageParser.parse(status, SystemStatus.class);
+    public SystemStatus retrieveSystemStatus() throws HttpRequestException, MessageParsingException {
+        return parseAndRethrow(doHttpRequest("/api/v2/status", GET, null), SystemStatus.class);
     }
 
-    public Settings retrieveSystemSettings() throws Exception {
-        final String status = doHttpRequest("/api/v2/settings", GET, null);
-        return RestMessageParser.parse(status, Settings.class);
+    public Settings retrieveSystemSettings() throws HttpRequestException, MessageParsingException {
+        return parseAndRethrow(doHttpRequest("/api/v2/settings", GET, null), Settings.class);
     }
 
-    public void sendBlink(final BlinkRequest request) throws Exception {
-        final String json = RestMessageParser.toJson(request);
-        doHttpRequest("/api/v2/blink", POST, json);
+    public void sendBlink(final BlinkRequest request) throws HttpRequestException {
+        doHttpRequest("/api/v2/blink", POST, serializeAndRethrow(request));
     }
 
-    public void updateSettings(final Settings settings) throws Exception {
-        final String json = RestMessageParser.toJson(settings);
-        doHttpRequest("/api/v2/settings", PUT, json);
+    public void updateSettings(final Settings settings) throws HttpRequestException {
+        doHttpRequest("/api/v2/settings", PUT, serializeAndRethrow(settings));
     }
 
     public void setUsername(final String username) {
@@ -81,55 +96,66 @@ public class ApiCaller {
         this.password = password;
     }
 
-    private String doHttpRequest(final String url, final String requestMethod, final String data) throws Exception {
+    private String doHttpRequest(final String url, final String requestMethod, final String data)
+            throws HttpRequestException {
         LOG.debug("JSON {}", data);
 
-        final String encodedAuthCredentials = Base64.encodeBase64String((username + ":" + password).getBytes());
-        final URL device = new URL(this.baseUrl + url);
-        final HttpURLConnection connection = (HttpURLConnection) device.openConnection();
-        connection.setConnectTimeout(10000);
-        connection.setReadTimeout(10000);
-        connection.setRequestProperty("Authorization", "Basic " + encodedAuthCredentials);
+        final String encodedAuthCredentials = Base64
+                .encodeBase64String((this.username + ":" + this.password).getBytes());
+        try {
+            final URL device = new URL(this.baseUrl + url);
+            final HttpURLConnection connection = (HttpURLConnection) device.openConnection();
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(10000);
+            connection.setRequestProperty("Authorization", "Basic " + encodedAuthCredentials);
 
-        // at the moment we only need GET method for heartbeat, but the there will be functionality that requires POST
-        switch (requestMethod) {
-            case POST:
-            case PUT:
-                connection.setDoOutput(true);
-                connection.addRequestProperty("Content-Type", "application/json");
-                connection.setRequestMethod(requestMethod);
-                connection.addRequestProperty("Content-Length", String.valueOf(data.length()));
-                try (OutputStreamWriter out = new OutputStreamWriter(connection.getOutputStream())) {
-                    out.write(data);
-                }
-                break;
-            case DELETE:
-                break;
-            case GET:
-            default:
-                // do nothing
-        }
-
-        final int responseCode = connection.getResponseCode();
-        LOG.debug("Response code = {}", responseCode);
-        if (responseCode < 400) {
-            try (final BufferedReader inputBuffer = new BufferedReader(
-                    new InputStreamReader(connection.getInputStream()))) {
-                final StringBuilder result = new StringBuilder();
-                String line;
-                while ((line = inputBuffer.readLine()) != null) {
-                    result.append(line);
-                }
-                LOG.debug("Result: {}", result.toString());
-                return result.toString();
+            // at the moment we only need GET method for heartbeat, but the there will be functionality that requires
+            // POST
+            switch (requestMethod) {
+                case POST:
+                case PUT:
+                    connection.setDoOutput(true);
+                    connection.addRequestProperty("Content-Type", "application/json");
+                    connection.setRequestMethod(requestMethod);
+                    connection.addRequestProperty("Content-Length", String.valueOf(data.length()));
+                    try (OutputStreamWriter out = new OutputStreamWriter(connection.getOutputStream())) {
+                        out.write(data);
+                    }
+                    break;
+                case DELETE:
+                    break;
+                case GET:
+                default:
+                    // do nothing
             }
-        } else if (responseCode == 401) {
-            throw new UnauthorizedException("Unauthorized");
-        } else if (responseCode == 404) {
-            throw new NotFoundException("End point not available");
-        } else {
-            LOG.debug("Message: {}", connection.getResponseMessage());
-            return connection.getResponseMessage();
+
+            final int responseCode = connection.getResponseCode();
+            LOG.debug("Response code = {}", responseCode);
+            if (responseCode < 400) {
+                try (final BufferedReader inputBuffer = new BufferedReader(
+                        new InputStreamReader(connection.getInputStream()))) {
+                    final StringBuilder result = new StringBuilder();
+                    String line;
+                    while ((line = inputBuffer.readLine()) != null) {
+                        result.append(line);
+                    }
+                    LOG.debug("Result: {}", result.toString());
+                    return result.toString();
+                }
+            } else if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                throw new UnauthorizedException("Unauthorized access to Renos API."
+                        + " Please authenticate first before making any further requests.");
+            } else if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+                throw new NotFoundException(
+                        "Endpoint not found." + " Please make sure you are connected to a compatible device.");
+            } else {
+                LOG.debug("Message: {}", connection.getResponseMessage());
+                return connection.getResponseMessage();
+            }
+        } catch (final HttpRequestException e) {
+            throw e;
+        } catch (final IOException e) {
+            throw new HttpRequestException(e);
         }
     }
 }

--- a/java/src/main/java/com/nedap/retail/example/rest/HttpRequestException.java
+++ b/java/src/main/java/com/nedap/retail/example/rest/HttpRequestException.java
@@ -1,0 +1,17 @@
+package com.nedap.retail.example.rest;
+
+import java.io.IOException;
+
+/**
+ * Exception possibly thrown when performing an HTTP request.
+ */
+public class HttpRequestException extends IOException {
+
+    public HttpRequestException(final Throwable throwable) {
+        super(throwable);
+    }
+
+    public HttpRequestException(final String message) {
+        super(message);
+    }
+}

--- a/java/src/main/java/com/nedap/retail/example/rest/MessageParsingException.java
+++ b/java/src/main/java/com/nedap/retail/example/rest/MessageParsingException.java
@@ -1,11 +1,14 @@
 package com.nedap.retail.example.rest;
 
+import java.io.IOException;
+
 /**
  * Missing Json elements
  */
-public class MessageParsingException extends Exception {
+public class MessageParsingException extends IOException {
 
-    public MessageParsingException(final String message) {
-        super(message);
+    public MessageParsingException(final String messageType) {
+        super("Parsing \"" + messageType + "\" message failed. "
+                + "Please make sure you are connected to a compatible device.");
     }
 }

--- a/java/src/main/java/com/nedap/retail/example/rest/MessageParsingException.java
+++ b/java/src/main/java/com/nedap/retail/example/rest/MessageParsingException.java
@@ -1,0 +1,11 @@
+package com.nedap.retail.example.rest;
+
+/**
+ * Missing Json elements
+ */
+public class MessageParsingException extends Exception {
+
+    public MessageParsingException(final String message) {
+        super(message);
+    }
+}

--- a/java/src/main/java/com/nedap/retail/example/rest/NotFoundException.java
+++ b/java/src/main/java/com/nedap/retail/example/rest/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.nedap.retail.example.rest;
+
+/**
+ * Error 404, page not found exception
+ */
+public class NotFoundException extends Exception {
+
+    public NotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/java/src/main/java/com/nedap/retail/example/rest/NotFoundException.java
+++ b/java/src/main/java/com/nedap/retail/example/rest/NotFoundException.java
@@ -3,7 +3,7 @@ package com.nedap.retail.example.rest;
 /**
  * Error 404, page not found exception
  */
-public class NotFoundException extends Exception {
+public class NotFoundException extends HttpRequestException {
 
     public NotFoundException(final String message) {
         super(message);

--- a/java/src/main/java/com/nedap/retail/example/rest/UnauthorizedException.java
+++ b/java/src/main/java/com/nedap/retail/example/rest/UnauthorizedException.java
@@ -3,7 +3,7 @@ package com.nedap.retail.example.rest;
 /**
  * Unauthorized access exception.
  */
-public class UnauthorizedException extends Exception {
+public class UnauthorizedException extends HttpRequestException {
 
     public UnauthorizedException(final String message) {
         super(message);

--- a/java/src/main/java/com/nedap/retail/example/websocket/client/ClientWebSocket.java
+++ b/java/src/main/java/com/nedap/retail/example/websocket/client/ClientWebSocket.java
@@ -2,6 +2,7 @@ package com.nedap.retail.example.websocket.client;
 
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.StatusCode;
+import org.eclipse.jetty.websocket.api.UpgradeException;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
@@ -47,7 +48,11 @@ public abstract class ClientWebSocket {
 
     @OnWebSocketError
     public void onError(final Throwable e) {
-        LOGGER.error("An error occurred while communicating via WebSocket", e);
+        if (e instanceof UpgradeException) {
+            LOGGER.info("Handshake failed. Please make sure to be connecting to a compatible device.");
+        } else {
+            LOGGER.error("An error occurred while communicating via WebSocket", e);
+        }
     }
 
     public void awaitConnect() throws InterruptedException {


### PR DESCRIPTION
In order to make the code forward compatible, some changes had to be
made. The following requirements had to be met:

* Ignore extra JSON fields
* Handle missing JSON fields (add null checks)
* Ignore extra HTTP end points
* Handle missing HTTP end points

These JSON field requirements apply to both the renos and the client
side, although this commit only applies to the example code (client).

In order to achieve this, null checks were added to all the fields
that are to be received in JSON format over the HTTP/WS communication.
Additionally, error messages were added to handle missing end points.

Note: Sending an empty string instead of JSON will cause a
NullPointerException on the renos side. It would be a good idea to
handle this in a more robust way. My proposal would be to ignore empty
strings and log (debug) that an empty string was received and ignored.