### PR TITLE
[#161277881] :lock: Fix CVE-2018-7489

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <jettyVersion>9.2.10.v20150310</jettyVersion>
         <slf4jVersion>1.7.7</slf4jVersion>
-        <jacksonVersion>2.9.2</jacksonVersion>
+        <jacksonVersion>2.9.7</jacksonVersion>
         <commons-codec.version>1.9</commons-codec.version>
         <java.version>1.8</java.version>
     </properties>


### PR DESCRIPTION
Upgrade Jackson to 2.9.7 all known CVE's are patched.