### PR TITLE
Upgrade Jackson for vulnerabilities 

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <jettyVersion>9.4.12.v20180830</jettyVersion>
         <slf4jVersion>1.7.7</slf4jVersion>
-        <jacksonVersion>2.9.7</jacksonVersion>
+        <jacksonVersion>2.9.8</jacksonVersion>
         <commons-codec.version>1.9</commons-codec.version>
         <java.version>1.8</java.version>
     </properties>


### PR DESCRIPTION
CVE-2018-19360
CVE-2018-19361
CVE-2018-19362
Vulnerable versions: >= 2.9.0, < 2.9.8

Fixed by moving to:
Patched version: 2.9.8
